### PR TITLE
Add pnpm start script and improve test logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "description": "An open source implementation of the Claude built-in text editor tool",
   "version": "0.0.1",
   "type": "module",
-  "bin": {
-    "mcp-server-text-editor": "dist/index.js"
-  },
+  "bin": "dist/index.js",
   "files": [
     "dist"
   ],
@@ -16,6 +14,7 @@
   "homepage": "https://github.com/bhouston/mcp-server-text-editor",
   "scripts": {
     "build": "tsc && chmod 755 ./dist/index.js",
+    "start": "node dist/index.js",
     "typecheck": "pnpm -r typecheck",
     "lint": "eslint . --fix",
     "format": "prettier . --write",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,21 @@ server.tool(
 );
 
 async function main() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error(
-    `${packageJson.name} MCP Server v${packageJson.version} running on stdio`,
-  );
+  console.error(`Starting ${packageJson.name} MCP Server v${packageJson.version}...`);
+  
+  try {
+    console.error('Initializing StdioServerTransport...');
+    const transport = new StdioServerTransport();
+    
+    console.error('Connecting server to transport...');
+    await server.connect(transport);
+    
+    console.error(`${packageJson.name} MCP Server v${packageJson.version} running on stdio`);
+    console.error('Server ready to accept commands');
+  } catch (error) {
+    console.error('Error during server startup:', error);
+    throw error;
+  }
 }
 
 main().catch((error) => {

--- a/test/helpers/mcp-client.ts
+++ b/test/helpers/mcp-client.ts
@@ -1,0 +1,96 @@
+import { ChildProcess } from 'child_process';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { Tool } from '@modelcontextprotocol/sdk/resources/tools/index.js';
+
+export class MCPClient {
+  private mcp: Client;
+  private transport: StdioClientTransport | null = null;
+  private tools: Tool[] = [];
+  private serverProcess: ChildProcess | null = null;
+
+  constructor() {
+    this.mcp = new Client({ name: 'mcp-test-client', version: '1.0.0' });
+  }
+
+  /**
+   * Connects to an MCP server
+   * @param serverScriptPath Path to the server script
+   * @returns Promise that resolves when connected
+   */
+  async connectToServer(serverScriptPath: string): Promise<Tool[]> {
+    try {
+      const isJs = serverScriptPath.endsWith('.js');
+      const isPy = serverScriptPath.endsWith('.py');
+
+      if (!isJs && !isPy) {
+        throw new Error('Server script must be a .js or .py file');
+      }
+
+      const command = isPy
+        ? process.platform === 'win32'
+          ? 'python'
+          : 'python3'
+        : process.execPath;
+
+      // Create transport that communicates with the server process
+      this.transport = new StdioClientTransport({
+        command,
+        args: [serverScriptPath],
+      });
+
+      // Connect the client to the transport
+      this.mcp.connect(this.transport);
+
+      // List available tools
+      const toolsResult = await this.mcp.listTools();
+
+      this.tools = toolsResult.tools;
+
+      return this.tools;
+    } catch (e) {
+      console.error('Failed to connect to MCP server: ', e);
+      throw e;
+    }
+  }
+
+  /**
+   * Disconnects from the server and cleans up resources
+   */
+  async disconnect(): Promise<void> {
+    try {
+      // The StdioClientTransport doesn't have a disconnect method,
+      // but when the process exits, it will clean up resources
+
+      this.tools = [];
+      this.transport = null;
+    } catch (error) {
+      console.error('Error during disconnect:', error);
+    }
+  }
+
+  /**
+   * Gets the list of available tools
+   */
+  getTools(): Tool[] {
+    return this.tools;
+  }
+
+  /**
+   * Calls a tool on the server
+   * @param toolName Name of the tool to call
+   * @param parameters Parameters to pass to the tool
+   * @returns Result from the tool
+   */
+  async callTool(
+    toolName: string,
+    parameters: Record<string, any>,
+  ): Promise<any> {
+    if (!this.transport) {
+      throw new Error('Not connected to server');
+    }
+
+    return await this.mcp.callTool(toolName, parameters);
+  }
+}

--- a/test/integration/server-client-connection.test.ts
+++ b/test/integration/server-client-connection.test.ts
@@ -1,0 +1,124 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+import { MCPClient } from '../helpers/mcp-client.js';
+
+// Get the directory of the current module
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Path to the server script (dist/index.js)
+const SERVER_SCRIPT_PATH = path.resolve(__dirname, '../../dist/index.js');
+
+describe('MCP Server-Client Integration', () => {
+  let client: MCPClient;
+  let tempDir: string;
+  let tempFilePath: string;
+
+  beforeAll(async () => {
+    // Create a temporary directory for file operations
+    tempDir = path.join(os.tmpdir(), `mcp-test-${Date.now()}`);
+    await fs.mkdir(tempDir, { recursive: true });
+    tempFilePath = path.join(tempDir, 'test-file.txt');
+
+    // Initialize client
+    client = new MCPClient();
+  });
+
+  afterAll(async () => {
+    // Clean up resources
+    await client.disconnect();
+
+    // Clean up temporary files
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch (error) {
+      console.error('Error cleaning up temp directory:', error);
+    }
+  });
+
+  it('should connect to the server and list available tools', async () => {
+    // Connect to the server
+    const tools = await client.connectToServer(SERVER_SCRIPT_PATH);
+
+    // Verify connection and tools
+    expect(tools).toBeDefined();
+    expect(tools.length).toBeGreaterThan(0);
+
+    // Verify that text_editor tool is available
+    const textEditorTool = tools.find((tool) => tool.name === 'text_editor');
+    expect(textEditorTool).toBeDefined();
+  }, 15000); // Increase timeout to 15 seconds for this test
+
+  it('should be able to create a file using the text_editor tool', async () => {
+    // Test file content
+    const testContent = 'This is a test file created by the MCP client.';
+
+    // Call the text_editor tool to create a file
+    const result = await client.callTool('text_editor', {
+      command: 'create',
+      path: tempFilePath,
+      file_text: testContent,
+      description: 'Creating a test file',
+    });
+
+    // Parse the result (which comes as a JSON string inside a content object)
+    const parsedResult = JSON.parse(result.content[0].text);
+
+    // Verify the result
+    expect(parsedResult.success).toBe(true);
+    expect(parsedResult.message).toContain('File created');
+
+    // Verify the file was actually created with the correct content
+    const fileContent = await fs.readFile(tempFilePath, 'utf8');
+    expect(fileContent).toBe(testContent);
+  }, 15000); // Increase timeout to 15 seconds
+
+  it('should be able to view a file using the text_editor tool', async () => {
+    // Call the text_editor tool to view the file
+    const result = await client.callTool('text_editor', {
+      command: 'view',
+      path: tempFilePath,
+      description: 'Viewing the test file',
+    });
+
+    // Parse the result
+    const parsedResult = JSON.parse(result.content[0].text);
+
+    // Verify the result
+    expect(parsedResult.success).toBe(true);
+    expect(parsedResult.message).toContain('File content');
+    expect(parsedResult.content).toContain('This is a test file');
+  }, 15000); // Increase timeout to 15 seconds
+
+  it('should be able to modify a file using the text_editor tool', async () => {
+    // Original content
+    const originalContent = 'This is a test file created by the MCP client.';
+    // New content
+    const newContent = 'This file has been modified by the MCP client.';
+
+    // Call the text_editor tool to replace content
+    const result = await client.callTool('text_editor', {
+      command: 'str_replace',
+      path: tempFilePath,
+      old_str: originalContent,
+      new_str: newContent,
+      description: 'Modifying the test file',
+    });
+
+    // Parse the result
+    const parsedResult = JSON.parse(result.content[0].text);
+
+    // Verify the result
+    expect(parsedResult.success).toBe(true);
+    expect(parsedResult.message).toContain('Successfully replaced text');
+
+    // Verify the file was actually modified
+    const fileContent = await fs.readFile(tempFilePath, 'utf8');
+    expect(fileContent).toBe(newContent);
+  }, 15000); // Increase timeout to 15 seconds
+});

--- a/test/integration/server-client-connection.test.ts
+++ b/test/integration/server-client-connection.test.ts
@@ -42,83 +42,141 @@ describe('MCP Server-Client Integration', () => {
   });
 
   it('should connect to the server and list available tools', async () => {
-    // Connect to the server
-    const tools = await client.connectToServer(SERVER_SCRIPT_PATH);
+    console.log('Test: Starting connection to server...');
+    
+    try {
+      // Connect to the server
+      console.log(`Test: Connecting to server at ${SERVER_SCRIPT_PATH}`);
+      const tools = await client.connectToServer(SERVER_SCRIPT_PATH);
+      console.log('Test: Successfully connected to server');
+      
+      // Verify connection and tools
+      console.log(`Test: Received ${tools?.length ?? 0} tools from server`);
+      expect(tools).toBeDefined();
+      expect(tools.length).toBeGreaterThan(0);
 
-    // Verify connection and tools
-    expect(tools).toBeDefined();
-    expect(tools.length).toBeGreaterThan(0);
-
-    // Verify that text_editor tool is available
-    const textEditorTool = tools.find((tool) => tool.name === 'text_editor');
-    expect(textEditorTool).toBeDefined();
-  }, 15000); // Increase timeout to 15 seconds for this test
+      // Verify that text_editor tool is available
+      const textEditorTool = tools.find((tool) => tool.name === 'text_editor');
+      console.log(`Test: Text editor tool ${textEditorTool ? 'found' : 'NOT found'}`);
+      expect(textEditorTool).toBeDefined();
+      
+      console.log('Test: Server connection test completed successfully');
+    } catch (error) {
+      console.error('Test ERROR: Failed to connect to server:', error);
+      throw error;
+    }
+  }, 30000); // Increase timeout to 30 seconds for this test
 
   it('should be able to create a file using the text_editor tool', async () => {
-    // Test file content
-    const testContent = 'This is a test file created by the MCP client.';
+    console.log('Test: Starting file creation test...');
+    
+    try {
+      // Test file content
+      const testContent = 'This is a test file created by the MCP client.';
+      console.log(`Test: Creating file at ${tempFilePath}`);
 
-    // Call the text_editor tool to create a file
-    const result = await client.callTool('text_editor', {
-      command: 'create',
-      path: tempFilePath,
-      file_text: testContent,
-      description: 'Creating a test file',
-    });
+      // Call the text_editor tool to create a file
+      console.log('Test: Calling text_editor tool with create command');
+      const result = await client.callTool('text_editor', {
+        command: 'create',
+        path: tempFilePath,
+        file_text: testContent,
+        description: 'Creating a test file',
+      });
+      console.log('Test: Received response from text_editor tool');
 
-    // Parse the result (which comes as a JSON string inside a content object)
-    const parsedResult = JSON.parse(result.content[0].text);
+      // Parse the result (which comes as a JSON string inside a content object)
+      console.log('Test: Parsing result');
+      const parsedResult = JSON.parse(result.content[0].text);
+      console.log(`Test: Parsed result - success: ${parsedResult.success}, message: ${parsedResult.message}`);
 
-    // Verify the result
-    expect(parsedResult.success).toBe(true);
-    expect(parsedResult.message).toContain('File created');
+      // Verify the result
+      expect(parsedResult.success).toBe(true);
+      expect(parsedResult.message).toContain('File created');
 
-    // Verify the file was actually created with the correct content
-    const fileContent = await fs.readFile(tempFilePath, 'utf8');
-    expect(fileContent).toBe(testContent);
-  }, 15000); // Increase timeout to 15 seconds
+      // Verify the file was actually created with the correct content
+      console.log('Test: Verifying file content');
+      const fileContent = await fs.readFile(tempFilePath, 'utf8');
+      console.log(`Test: File content length: ${fileContent.length}`);
+      expect(fileContent).toBe(testContent);
+      
+      console.log('Test: File creation test completed successfully');
+    } catch (error) {
+      console.error('Test ERROR: Failed during file creation test:', error);
+      throw error;
+    }
+  }, 30000); // Increase timeout to 30 seconds
 
   it('should be able to view a file using the text_editor tool', async () => {
-    // Call the text_editor tool to view the file
-    const result = await client.callTool('text_editor', {
-      command: 'view',
-      path: tempFilePath,
-      description: 'Viewing the test file',
-    });
+    console.log('Test: Starting file view test...');
+    
+    try {
+      // Call the text_editor tool to view the file
+      console.log(`Test: Viewing file at ${tempFilePath}`);
+      const result = await client.callTool('text_editor', {
+        command: 'view',
+        path: tempFilePath,
+        description: 'Viewing the test file',
+      });
+      console.log('Test: Received response from text_editor tool');
 
-    // Parse the result
-    const parsedResult = JSON.parse(result.content[0].text);
+      // Parse the result
+      console.log('Test: Parsing result');
+      const parsedResult = JSON.parse(result.content[0].text);
+      console.log(`Test: Parsed result - success: ${parsedResult.success}, message: ${parsedResult.message}`);
 
-    // Verify the result
-    expect(parsedResult.success).toBe(true);
-    expect(parsedResult.message).toContain('File content');
-    expect(parsedResult.content).toContain('This is a test file');
-  }, 15000); // Increase timeout to 15 seconds
+      // Verify the result
+      expect(parsedResult.success).toBe(true);
+      expect(parsedResult.message).toContain('File content');
+      expect(parsedResult.content).toContain('This is a test file');
+      
+      console.log('Test: File view test completed successfully');
+    } catch (error) {
+      console.error('Test ERROR: Failed during file view test:', error);
+      throw error;
+    }
+  }, 30000); // Increase timeout to 30 seconds
 
   it('should be able to modify a file using the text_editor tool', async () => {
-    // Original content
-    const originalContent = 'This is a test file created by the MCP client.';
-    // New content
-    const newContent = 'This file has been modified by the MCP client.';
+    console.log('Test: Starting file modification test...');
+    
+    try {
+      // Original content
+      const originalContent = 'This is a test file created by the MCP client.';
+      // New content
+      const newContent = 'This file has been modified by the MCP client.';
+      console.log(`Test: Modifying file at ${tempFilePath}`);
 
-    // Call the text_editor tool to replace content
-    const result = await client.callTool('text_editor', {
-      command: 'str_replace',
-      path: tempFilePath,
-      old_str: originalContent,
-      new_str: newContent,
-      description: 'Modifying the test file',
-    });
+      // Call the text_editor tool to replace content
+      console.log('Test: Calling text_editor tool with str_replace command');
+      const result = await client.callTool('text_editor', {
+        command: 'str_replace',
+        path: tempFilePath,
+        old_str: originalContent,
+        new_str: newContent,
+        description: 'Modifying the test file',
+      });
+      console.log('Test: Received response from text_editor tool');
 
-    // Parse the result
-    const parsedResult = JSON.parse(result.content[0].text);
+      // Parse the result
+      console.log('Test: Parsing result');
+      const parsedResult = JSON.parse(result.content[0].text);
+      console.log(`Test: Parsed result - success: ${parsedResult.success}, message: ${parsedResult.message}`);
 
-    // Verify the result
-    expect(parsedResult.success).toBe(true);
-    expect(parsedResult.message).toContain('Successfully replaced text');
+      // Verify the result
+      expect(parsedResult.success).toBe(true);
+      expect(parsedResult.message).toContain('Successfully replaced text');
 
-    // Verify the file was actually modified
-    const fileContent = await fs.readFile(tempFilePath, 'utf8');
-    expect(fileContent).toBe(newContent);
-  }, 15000); // Increase timeout to 15 seconds
+      // Verify the file was actually modified
+      console.log('Test: Verifying file modification');
+      const fileContent = await fs.readFile(tempFilePath, 'utf8');
+      console.log(`Test: Modified file content: "${fileContent}"`);
+      expect(fileContent).toBe(newContent);
+      
+      console.log('Test: File modification test completed successfully');
+    } catch (error) {
+      console.error('Test ERROR: Failed during file modification test:', error);
+      throw error;
+    }
+  }, 30000); // Increase timeout to 30 seconds
 });


### PR DESCRIPTION
## Add pnpm start script and improve test logging

This PR adds a "pnpm start" script to easily start the server and adds comprehensive logging to the integration tests to help diagnose where tests might be hanging.

### Changes
1. Added "pnpm start" script to package.json
2. Added detailed logging to server-client-connection.test.ts
3. Added logging to the MCP client helper
4. Added more verbose logging to the server startup process

The enhanced logging should help identify where integration tests might be hanging, whether during server startup, connection establishment, or during tool calls.

Closes #11